### PR TITLE
Working with times and dates

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - working_with_times_and_dates
 jobs:
 
   build-and-push:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-
+      - working_with_times_and_dates
 jobs:
 
   build-and-push:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM registry.access.redhat.com/ubi8/python-39
 
 # Set timezone
-ENV TZ=Europe/Helsinki
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+RUN apt-get update && \
+    apt-get install -yq tzdata && \
+    ln -fs /usr/share/zoneinfo/Europe/Helsinki /etc/localtime && \
+    dpkg-reconfigure -f noninteractive tzdata
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,5 @@
 FROM registry.access.redhat.com/ubi8/python-39
 
-# Set timezone
-RUN apt-get update && \
-    apt-get install -yq tzdata && \
-    ln -fs /usr/share/zoneinfo/Europe/Helsinki /etc/localtime && \
-    dpkg-reconfigure -f noninteractive tzdata
-
 WORKDIR /usr/src/app
 
 COPY ./src .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM registry.access.redhat.com/ubi8/python-39
 
+# Set timezone
+ENV TZ=Europe/Helsinki
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 WORKDIR /usr/src/app
 
 COPY ./src .

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -22,4 +22,8 @@ scheduler = APScheduler()
 scheduler.init_app(app)
 scheduler.start()
 
+# make format_datestring accessible from jinja templates
+from src.tools.date_converter import format_datestring
+app.jinja_env.globals.update(format_datestring=format_datestring)
+
 from src import routes

--- a/src/routes.py
+++ b/src/routes.py
@@ -675,6 +675,5 @@ def job1():
     """
     Every hour go through a list of a all open surveys. Close all surveys which have an end_date equal or less to now
     """
-    print(f"Checking for surveys to close: {datetime.now()}")
     with app.app_context():
         survey_service.check_for_surveys_to_close()

--- a/src/routes.py
+++ b/src/routes.py
@@ -670,10 +670,11 @@ def get_choices(survey_id):
 """
 TASKS:
 """
-@scheduler.task('cron', id='do_job_1', hour='*')
+@scheduler.task('cron', id='do_job_1', hour='*', minute="*", second="*")
 def job1():
     """
     Every hour go through a list of a all open surveys. Close all surveys which have an end_date equal or less to now
     """
+    print(f"Checking for surveys to close: {datetime.now()}")
     with app.app_context():
         survey_service.check_for_surveys_to_close()

--- a/src/routes.py
+++ b/src/routes.py
@@ -670,7 +670,7 @@ def get_choices(survey_id):
 """
 TASKS:
 """
-@scheduler.task('cron', id='do_job_1', hour='*', minute="*", second="*")
+@scheduler.task('cron', id='do_job_1', hour='*')
 def job1():
     """
     Every hour go through a list of a all open surveys. Close all surveys which have an end_date equal or less to now

--- a/src/routes.py
+++ b/src/routes.py
@@ -24,7 +24,6 @@ from src.tools.parsers import parser_elomake_csv_to_dict
 from src.entities.user import User
 from functools import wraps
 from datetime import datetime
-from src.tools.date_converter import get_time_helsinki
 
 """
 DECORATORS:

--- a/src/services/survey_service.py
+++ b/src/services/survey_service.py
@@ -250,9 +250,8 @@ class SurveyService:
         for survey in surveys:
             survey_id = survey.id
             survey_time_end = self._survey_repository.get_survey_time_end(survey_id)
-            #print(f'Survey id {survey_id}, closes at {survey_time_end}')
-            closin_time = time_to_close(survey_time_end)
-            if closin_time:
+            closing_time = time_to_close(survey_time_end)
+            if closing_time:
                 #print(f"Closing survey {survey.surveyname}")
                 self._survey_repository.close_survey(survey_id)
                 #print(f"Closed survey {survey.surveyname}")

--- a/src/services/survey_service.py
+++ b/src/services/survey_service.py
@@ -250,6 +250,7 @@ class SurveyService:
         for survey in surveys:
             survey_id = survey.id
             survey_time_end = self._survey_repository.get_survey_time_end(survey_id)
+            print(f'Survey id {survey_id}, closes at {survey_time_end}')
             closin_time = time_to_close(survey_time_end)
             if closin_time:
                 #print(f"Closing survey {survey.surveyname}")

--- a/src/services/survey_service.py
+++ b/src/services/survey_service.py
@@ -250,7 +250,7 @@ class SurveyService:
         for survey in surveys:
             survey_id = survey.id
             survey_time_end = self._survey_repository.get_survey_time_end(survey_id)
-            print(f'Survey id {survey_id}, closes at {survey_time_end}')
+            #print(f'Survey id {survey_id}, closes at {survey_time_end}')
             closin_time = time_to_close(survey_time_end)
             if closin_time:
                 #print(f"Closing survey {survey.surveyname}")

--- a/src/templates/create_survey.html
+++ b/src/templates/create_survey.html
@@ -71,7 +71,33 @@
           value="{{survey.startdate}}"
         {% endif %}
         >
-      <label for="starttime" class="time-label">Kello:</label><input type="time" name="starttime" id="starttime" class="datetime-input-field" validation-regex="\d\d\:\d\d" validation-text="Ajan tulee olla muodossa hh.mm"/>
+      <label for="starttime" class="time-label">Kello:</label>
+      <select name="starttime" id="starttime" class="datetime-input-field">
+        <option value="00:00">00:00</option>
+        <option value="01:00">01:00</option>
+        <option value="02:00">02:00</option>
+        <option value="03:00">03:00</option>
+        <option value="04:00">04:00</option>
+        <option value="05:00">05:00</option>
+        <option value="06:00">06:00</option>
+        <option value="07:00">07:00</option>
+        <option value="08:00">08:00</option>
+        <option value="09:00">09:00</option>
+        <option value="10:00">10:00</option>
+        <option value="11:00">11:00</option>
+        <option value="12:00">12:00</option>
+        <option value="13:00">13:00</option>
+        <option value="14:00">14:00</option>
+        <option value="15:00">15:00</option>
+        <option value="16:00">16:00</option>
+        <option value="17:00">17:00</option>
+        <option value="18:00">18:00</option>
+        <option value="19:00">19:00</option>
+        <option value="20:00">20:00</option>
+        <option value="21:00">21:00</option>
+        <option value="22:00">22:00</option>
+        <option value="23:00">23:00</option>
+      </select>
       <br/>
       <ul class="validation-warnings-list hidden">
         <li><span class="input-validation-warning" id="startdate-validation-warning"></span></li>
@@ -79,7 +105,33 @@
       </ul>
       <label>Vastausaika päättyy:</label><br />
       <input data-role="date" type="text" id="end-date" class="datetime-input-field" name="enddate" validation-regex="\d\d\.\d\d\.\d\d\d\d" validation-text="Päivämäärän tulee olla muodossa pp.kk.yyyy">
-      <label for="endtime" class="time-label">Kello:</label><input type="time" name="endtime" id="endtime" class="datetime-input-field" validation-regex="\d\d\:\d\d" validation-text="Ajan tulee olla muodossa hh.mm"/>
+      <label for="endtime" class="time-label">Kello:</label>
+      <select name="endtime" id="endtime" class="datetime-input-field">
+        <option value="00:00">00:00</option>
+        <option value="01:00">01:00</option>
+        <option value="02:00">02:00</option>
+        <option value="03:00">03:00</option>
+        <option value="04:00">04:00</option>
+        <option value="05:00">05:00</option>
+        <option value="06:00">06:00</option>
+        <option value="07:00">07:00</option>
+        <option value="08:00">08:00</option>
+        <option value="09:00">09:00</option>
+        <option value="10:00">10:00</option>
+        <option value="11:00">11:00</option>
+        <option value="12:00">12:00</option>
+        <option value="13:00">13:00</option>
+        <option value="14:00">14:00</option>
+        <option value="15:00">15:00</option>
+        <option value="16:00">16:00</option>
+        <option value="17:00">17:00</option>
+        <option value="18:00">18:00</option>
+        <option value="19:00">19:00</option>
+        <option value="20:00">20:00</option>
+        <option value="21:00">21:00</option>
+        <option value="22:00">22:00</option>
+        <option value="23:00">23:00</option>
+      </select>
       <ul class="validation-warnings-list hidden">
         <li><span class="input-validation-warning" id="enddate-validation-warning"></span></li>
         <li><span class="input-validation-warning" id="endtime-validation-warning"></span></li>

--- a/src/templates/create_survey.html
+++ b/src/templates/create_survey.html
@@ -10,15 +10,6 @@
 {% block content %}
   <script src="https://code.jquery.com/jquery-3.6.0.js"></script>
   <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.js"></script>
-  <!-- Removing sortability
-  <script>
-    $( function() {
-            $("#choiceTable").sortable({
-              items: "tr:not(#newRow)"
-            });
-    })
-  </script>
-  -->
   <script>
       $( document ).ready(function() {
         $("#start-date").datepicker({

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -43,7 +43,7 @@
     <a href="/surveys/{{ d[0] }}/answers" class="list-group-item list-group-item-action flex-column align-items-start" >
       <div class="d-flex w-100 justify-content-between">
         <h5 class="mb-1"><img src="{{ url_for('static', filename='images/assignment_white_36dp.svg') }}" alt="" width="34" height="30" class="d-inline-block align-text-top">  {{ d[1] }}</h5>
-        <small class="text-muted">Vastausaika loppuu {{ d[3] }}</small>
+        <small class="text-muted">Vastausaika loppuu {{ format_datestring(d[3]) }}</small>
       </div>
       <small class="text-muted">Kyselyyn on vastannut {{ d[2] }} opiskelijaa</small>
     </a></br>

--- a/src/templates/survey.html
+++ b/src/templates/survey.html
@@ -25,7 +25,7 @@
 </script>
 <div class="row">
     <h5><img src="{{ url_for('static', filename='images/assignment_white_36dp.svg') }}" alt="" width="34" height="30" class="d-inline-block align-text-top">  {{ survey_name }}</h5>
-    <label>Vastausaika päättyy {{ enddate }}</label></br></br>
+    <label>Vastausaika päättyy {{ format_datestring(enddate) }}</label></br></br>
     <label>{{ desc }}</label>
     <input type="hidden" id="max_bad_choices" value="{{ max_bad_choices }}">
     <div class="col">
@@ -35,12 +35,9 @@
                     <i>Raahaa oikean reunan listasta vähintään {{ min_choices }} vaihtoehtoa vihreään laatikkoon.</i>
                 </p>
             </div>
-            {% if allow_search_visibility is sameas true %}
             <div class="col-sm">
                 <input id="searchChoices" type="text" placeholder="Etsi..."></br></br>
             </div>
-            {% endif %}
-            
         </div>
         <div class="row">
             <div class="col">

--- a/src/templates/survey.html
+++ b/src/templates/survey.html
@@ -35,9 +35,11 @@
                     <i>Raahaa oikean reunan listasta vähintään {{ min_choices }} vaihtoehtoa vihreään laatikkoon.</i>
                 </p>
             </div>
+            {% if allow_search_visibility is sameas true %}
             <div class="col-sm">
                 <input id="searchChoices" type="text" placeholder="Etsi..."></br></br>
             </div>
+            {% endif %}
         </div>
         <div class="row">
             <div class="col">

--- a/src/templates/surveys.html
+++ b/src/templates/surveys.html
@@ -32,7 +32,7 @@
             <a href="/surveys/create?fromTemplate={{ row[0] }}">Kopioi kysely</a>
           </td>
           {% endif %}
-          <td>{{ row[4] }}</td>
+          <td>{{ format_datestring(row[4]) }}</td>
 
         </tr>
         {% endfor %}

--- a/src/tools/date_converter.py
+++ b/src/tools/date_converter.py
@@ -1,14 +1,5 @@
 from datetime import datetime, timedelta, timezone
 
-def get_time_helsinki():
-    """
-    Convert the current time to GMT+3. Pretty sure this is not needed, but might cause problems
-    if not implemented.
-    """
-    now = datetime.now().replace(microsecond=0)
-    tz = timezone(timedelta(hours=3))
-    helsinki = now.astimezone(tz)
-    return helsinki
 
 def time_to_close(time_to_close):
     """
@@ -17,12 +8,8 @@ def time_to_close(time_to_close):
     Args:
         time_to_close: The date and time when the survey closes
     """
-    now = get_time_helsinki()
-    tz = timezone(timedelta(hours=3))
-    time_to_close = time_to_close.astimezone(tz)
-    if time_to_close <= now:
-        return True
-    return False
+
+    return time_to_close <= datetime.now()
 
 def format_datestring(input_datetime):
     output_format = "%d.%m.%Y %H:%M"

--- a/src/tools/date_converter.py
+++ b/src/tools/date_converter.py
@@ -24,3 +24,12 @@ def time_to_close(time_to_close):
         return True
     return False
 
+def format_datestring(input_datetime):
+    output_format = "%d.%m.%Y %H:%M"
+    try:
+        return datetime.strftime(input_datetime, output_format)
+    except:
+        # To prevent crashing in case a non datetime input is given 
+        return input_datetime
+
+


### PR DESCRIPTION
Addresses multiple issues concerning how dates and times are handled within the application

## Displaying datetimes in the front-end

To ensure that every datetime shown in the front-end is formatted in the same way, the formatting is done with a common funtion shown below. This way if the format ever needs to be changed it can be done by changing the format set in the output_format variable and the change should be reflected anywhere
```
# ./src/tools/date_converter

def format_datestring(input_datetime):
    output_format = "%d.%m.%Y %H:%M"
    try:
        return datetime.strftime(input_datetime, output_format)
    except:
        # To prevent crashing in case a non datetime input is given 
        return input_datetime
```
The format_datestring function is made accessible to Jinja in ```./src/__init__.py``` 

After this it is possible call it in a Jinja -template example from survey.html below:

```
<label>Vastausaika päättyy {{ format_datestring(enddate) }}</label>
```

## Closing the surveys at the right time

Previously there was a 3 hour delay in when a survey was supposed to be closed to when it was actually closed. The root cause for this was that the staging container was set to operate in UTC -time. By changing the deployment environment timezone, this issue should be resolved and we do not need to do any timezone conversions in the application itself. 

## Allowing closing time to be set only in full one hour intervals

Since the application logic only goes through and checks the open surveys for closing at every full hour, it was pointless and misleading to have a possibility to set it in minute intervals. This is now changed and the create_survey.html template contains a dropdown input to select from hours between 00:00 to 23:00